### PR TITLE
Added new hook to wizard to run callback bef…

### DIFF
--- a/packages/client/src/components/FireboltProvider/hook/index.ts
+++ b/packages/client/src/components/FireboltProvider/hook/index.ts
@@ -32,6 +32,8 @@ function useFireboltProvider({
     setIsFormLoading,
     formFlowHasBeenFinished,
     setFormFlowHasBeenFinished,
+    triggerOnBeforeProceed,
+    setTriggerOnBeforeProceed
   } = useStates()
 
   const {
@@ -103,6 +105,7 @@ function useFireboltProvider({
     { extraRequestsMetaData = {} }: IRequestMetadata = {}
   ): Promise<void | Object> {
     setIsFormLoading(true)
+    setTriggerOnBeforeProceed(true)
     const isLastStep = currentStep?.data?.slug === formflowMetadata?.lastStep
     return formEngine.current
       .nextStep(currentStep.data.slug, stepFieldsPayload, {
@@ -219,7 +222,9 @@ function useFireboltProvider({
     getRequestsMetadata,
     uploadFile,
     clearSession,
-    clearRemoteFieldError
+    clearRemoteFieldError,
+    triggerOnBeforeProceed,
+    setTriggerOnBeforeProceed
   }
 }
 

--- a/packages/client/src/components/FireboltProvider/hook/useStates.ts
+++ b/packages/client/src/components/FireboltProvider/hook/useStates.ts
@@ -3,11 +3,14 @@ import { useState } from "react";
 export default function useStates() {
   const [isFormLoading, setIsFormLoading] = useState<boolean>(true);
   const [formFlowHasBeenFinished, setFormFlowHasBeenFinished] = useState<boolean>(false);
+  const [triggerOnBeforeProceed, setTriggerOnBeforeProceed] = useState<boolean>(false)
 
   return {
     isFormLoading,
     setIsFormLoading,
     formFlowHasBeenFinished,
     setFormFlowHasBeenFinished,
+    triggerOnBeforeProceed,
+    setTriggerOnBeforeProceed
   };
 }

--- a/packages/client/src/components/Wizard/hook.ts
+++ b/packages/client/src/components/Wizard/hook.ts
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
-import { useFirebolt } from "../../hooks/useFirebolt";
+import { useEffect } from "react"
+import { useFirebolt } from "../../hooks/useFirebolt"
 import { IWizardHook } from "../../types"
 
 export default function useWizard({
@@ -7,7 +7,8 @@ export default function useWizard({
   onConnectionError,
   onFinishForm,
   onBeforeChangeStep,
-}: IWizardHook) { 
+  onBeforeProceed,
+}: IWizardHook) {
   const {
     isFormLoading,
     currentStep,
@@ -18,52 +19,65 @@ export default function useWizard({
     commitStepChange,
 
     connectionError,
-  } = useFirebolt(); 
+    setTriggerOnBeforeProceed,
+    triggerOnBeforeProceed,
+  } = useFirebolt()
 
-  useEffect(onStepChangeHandler, [currentStep]);
+  useEffect(onStepChangeHandler, [currentStep])
 
   useEffect(() => {
-    if (!!stagedStep) onBeforeStepChangeHandler();
-  }, [stagedStep]);
+    if (!!stagedStep) onBeforeStepChangeHandler()
+  }, [stagedStep])
 
-  useEffect(onConnectionErrorHandler, [connectionError]);
-  useEffect(onFormFinishedCallback, [formFlowHasBeenFinished]);
+  useEffect(onConnectionErrorHandler, [connectionError])
+  useEffect(onFormFinishedCallback, [formFlowHasBeenFinished])
+
+  useEffect(onBeforeProceedHandler, [triggerOnBeforeProceed])
 
   function onConnectionErrorHandler() {
     if (connectionError && !!onConnectionError) {
-      onConnectionError();
+      onConnectionError()
+    }
+  }
+
+  function onBeforeProceedHandler() {
+    if (!!triggerOnBeforeProceed) {
+      if (!!onBeforeProceed) {
+        onBeforeProceed(currentStep)
+      }
+      setTriggerOnBeforeProceed(false)
     }
   }
 
   function onBeforeStepChangeHandler() {
-    const proceedCallback = () => commitStepChange();
+    const proceedCallback = () => commitStepChange()
 
     if (!!onBeforeChangeStep) {
       onBeforeChangeStep(proceedCallback, {
         leavingStep: currentStep,
         enteringStep: stagedStep,
-      });
+      })
     } else {
-      proceedCallback();
+      proceedCallback()
     }
   }
 
   function onStepChangeHandler() {
-    const notIsFirstStepRendered = !!lastVisitedStep?.position;
+    const notIsFirstStepRendered = !!lastVisitedStep?.position
     if (notIsFirstStepRendered && !!onChangeStep) {
-      onChangeStep({ sentStep: lastVisitedStep, currentStep });
+      onChangeStep({ sentStep: lastVisitedStep, currentStep })
     }
   }
 
   function onFormFinishedCallback() {
     if (!!formFlowHasBeenFinished && !!onFinishForm) {
-      const payload = formEndPayload || {};
-      onFinishForm(payload);
+      const payload = formEndPayload || {}
+      onFinishForm(payload)
     }
   }
 
   return {
     isFormLoading,
     currentStepSlug: currentStep?.data?.slug,
-  };
+  }
 }

--- a/packages/client/src/components/Wizard/index.tsx
+++ b/packages/client/src/components/Wizard/index.tsx
@@ -13,12 +13,14 @@ const Wizard = ({
   onConnectionError,
   onFinishForm,
   onBeforeChangeStep,
+  onBeforeProceed
 }: IWizardComponent) => {
   const { isFormLoading, currentStepSlug } = useWizard({
     onChangeStep,
     onConnectionError,
     onFinishForm,
     onBeforeChangeStep,
+    onBeforeProceed
   });
 
   return (

--- a/packages/client/src/context.ts
+++ b/packages/client/src/context.ts
@@ -31,6 +31,8 @@ export interface IFireboltContext {
   clearRemoteFieldError(fieldSlug: string): void
 
   connectionError?: any
+  triggerOnBeforeProceed: boolean
+  setTriggerOnBeforeProceed(arg:boolean): void
 }
 
 const FireboltContext = createContext<IFireboltContext>({} as IFireboltContext)

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -47,6 +47,7 @@ export interface IWizardHook {
   onConnectionError?(arg0?: object): void
   onFinishForm?(arg0?: object): void
   onBeforeChangeStep?(arg0?: Function, arg1?: IStepProps): void
+  onBeforeProceed?(sendingStepData): void
 }
 
 export interface IWizardComponent {
@@ -56,6 +57,7 @@ export interface IWizardComponent {
   onConnectionError?(arg0?: object): void
   onFinishForm?(arg0?: object): void
   onBeforeChangeStep?(arg0?: Function, arg1?: IStepProps): void
+  onBeforeProceed?(sendingStepData): void
 }
 
 export interface IUseFireboltForm {

--- a/packages/lab/src/app/pages/debug/FormDemo.jsx
+++ b/packages/lab/src/app/pages/debug/FormDemo.jsx
@@ -135,7 +135,11 @@ const FormDemo = () => {
           proceed()
         }}
         onChangeStep={({ sentStep, currentStep }) => {
+          console.log({sentStep, currentStep})
           // console.log("changed step:", { sentStep, currentStep });
+        }}
+        onBeforeProceed={(currentStep) => {
+          console.log(currentStep)
         }}
       >
         <Wizard.Step match="*" component={DefaultTemplate} />


### PR DESCRIPTION
…ore request a new step

<!--- Provide a general summary of your changes in the title above -->

#### Description

<!--- Describe your changes in detail -->

added new hook to wizard to run callback before request a new step
the callback `onBeforeProceed` runs before the `next` request

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

---

#### Screenshots and links

---