### PR TITLE
fix(client): :bug: masks with the character "/" error fixed

### DIFF
--- a/packages/client/src/components/FireboltForm/InputHolder/hook/helpers.ts
+++ b/packages/client/src/components/FireboltForm/InputHolder/hook/helpers.ts
@@ -63,7 +63,7 @@ export function parseMask(rawMask: ParseMaskArg): ParseMaskReturn | undefined {
     }
   } else if (Array.isArray(rawMask)) {
     return rawMask.map((item) => {
-      const isEncodedRegex = typeof item === "string" && item.startsWith("/")
+      const isEncodedRegex = typeof item === "string" && item.startsWith("/") && item.endsWith("/") && item !== "/"
       const isRegex = item instanceof RegExp
       if (isRegex) {
         return item


### PR DESCRIPTION
Masks that contained the character "/" as part of them weren't working.

#### Description

The masks that contained the character "/" weren't working, because the mask is passed as an array, and each item is a character, and a character that was only "/" was being read as a regex (even though it wasn't).

---

#### Motivation and Context

The backend testers found out that the date mask wasn't working, and only the first two characters were being put on it.

---

#### Screenshots and links

<img width="559" alt="Captura de Tela 2022-10-31 às 16 48 12" src="https://user-images.githubusercontent.com/7524162/199120467-3f38411b-08f7-48ed-9f12-fbf6f9aecfef.png">


---