### PR TITLE
feat: added manually set field remote error on firebolt provider

### DIFF
--- a/packages/client/src/components/FireboltProvider/hook/index.ts
+++ b/packages/client/src/components/FireboltProvider/hook/index.ts
@@ -212,6 +212,19 @@ function useFireboltProvider({
     }
   }
 
+  function addFieldRemoteError(fieldSlug: string, errorMessage: string) {
+    const newRemoteError = {
+      "slug": fieldSlug,
+      "validationResults": [
+        {
+          "isValid": false,
+          "message": errorMessage,
+        },
+      ],
+    }
+    setRemoteErrors([...remoteErrors, newRemoteError])
+  }
+
   function uploadFile(file, fileName: string) {
     return formEngine.current.uploadFile(file, fileName)
   }
@@ -241,6 +254,7 @@ function useFireboltProvider({
     clearRemoteFieldError,
     beforeProceedPayload,
     setBeforeProceedPayload,
+    addFieldRemoteError
   }
 }
 

--- a/packages/client/src/context.ts
+++ b/packages/client/src/context.ts
@@ -33,6 +33,7 @@ export interface IFireboltContext {
   connectionError?: any
   beforeProceedPayload: boolean
   setBeforeProceedPayload(arg:boolean): void
+  addFieldRemoteError(fieldSlug: string, errorMessage: string)
 }
 
 const FireboltContext = createContext<IFireboltContext>({} as IFireboltContext)

--- a/packages/lab/src/app/components/templates/DefaultTemplate.jsx
+++ b/packages/lab/src/app/components/templates/DefaultTemplate.jsx
@@ -68,10 +68,14 @@ const mockFields = [
 ]
 
 const DefaultTemplate = ({ fireboltStep }) => {
-  const { remoteErrors } = useFirebolt()
+  const { remoteErrors, addFieldRemoteError } = useFirebolt()
   useEffect(() => {
     console.log(remoteErrors)
   }, [remoteErrors])
+
+  useEffect(() => {
+    addFieldRemoteError("full_name", "cebola")
+  }, [])
 
   return (
     <div className="tooltip-wrapper">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

#### Description

<!--- Describe your changes in detail -->

* now is possible to add a remote field error manually to firebolt provider

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

---

#### Screenshots and links

---