### PR TITLE
feat: :sparkles: new state value last sent payload

### DIFF
--- a/packages/client/src/components/FireboltProvider/hook/index.ts
+++ b/packages/client/src/components/FireboltProvider/hook/index.ts
@@ -34,6 +34,8 @@ function useFireboltProvider({
     setFormFlowHasBeenFinished,
     beforeProceedPayload,
     setBeforeProceedPayload,
+    lastSentPayload,
+    setLastSentPayload,
   } = useStates()
 
   const {
@@ -106,6 +108,8 @@ function useFireboltProvider({
   ): Promise<void | Object> {
     setIsFormLoading(true)
     setBeforeProceedPayload(stepFieldsPayload)
+    setLastSentPayload(stepFieldsPayload)
+
     const isLastStep = currentStep?.data?.slug === formflowMetadata?.lastStep
     return formEngine.current
       .nextStep(currentStep.data.slug, stepFieldsPayload, {
@@ -256,7 +260,9 @@ function useFireboltProvider({
     clearRemoteFieldError,
     beforeProceedPayload,
     setBeforeProceedPayload,
-    addFieldRemoteError
+    addFieldRemoteError,
+    lastSentPayload,
+    setLastSentPayload,
   }
 }
 

--- a/packages/client/src/components/FireboltProvider/hook/useStates.ts
+++ b/packages/client/src/components/FireboltProvider/hook/useStates.ts
@@ -4,6 +4,7 @@ export default function useStates() {
   const [isFormLoading, setIsFormLoading] = useState<boolean>(true);
   const [formFlowHasBeenFinished, setFormFlowHasBeenFinished] = useState<boolean>(false);
   const [beforeProceedPayload, setBeforeProceedPayload] = useState<any>(null)
+  const [lastSentPayload, setLastSentPayload] = useState<any>(null)
 
   return {
     isFormLoading,
@@ -11,6 +12,8 @@ export default function useStates() {
     formFlowHasBeenFinished,
     setFormFlowHasBeenFinished,
     beforeProceedPayload,
-    setBeforeProceedPayload
+    setBeforeProceedPayload,
+    lastSentPayload,
+    setLastSentPayload,
   };
 }

--- a/packages/client/src/context.ts
+++ b/packages/client/src/context.ts
@@ -10,6 +10,7 @@ export interface IFireboltContext {
   //states
   isFormLoading?: boolean
   formFlowHasBeenFinished?: boolean
+  lastSentPayload?: Object
   //data
   currentStep?: IDefaultStep
   stagedStep?: IFormStep


### PR DESCRIPTION
new state value last sent payload

#### Description

we are now sending the last value the user sent to firebolt.
This is useful because when the backend sent an error we couldn't get the values the user sent before the error.
We need it now because the sorting hat call asks for the payload and we need to put it after the next call.

---

#### Motivation and Context

The analysts asked us to show the sorting hat error after the next and only if the backend sent an error "should_show_sortinghat". 
Since the next was already called and an error ocurred, we didn't had the payload to sent to the sorting hat.

---