### PR TITLE
fix: 🐛 remove autocomplete none to use the default off instead

### DIFF
--- a/packages/blueberry/Widgets/EmailWidget/index.jsx
+++ b/packages/blueberry/Widgets/EmailWidget/index.jsx
@@ -18,7 +18,6 @@ const EmailWidget = ({
 }) => {
   return (
     <EmailField
-      autoComplete="none"
       required={isRequired}
       optional={isOptional}
       invalid={hasError}

--- a/packages/blueberry/Widgets/NumberWidget/index.jsx
+++ b/packages/blueberry/Widgets/NumberWidget/index.jsx
@@ -2,7 +2,7 @@ import React from "react"
 import TextWidget from "../TextWidget"
 
 const NumberWidget = (props) => {
-  return <TextWidget {...props} htmlType="number" autoComplete="none" />
+  return <TextWidget {...props} htmlType="number" />
 }
 
 export default NumberWidget

--- a/packages/blueberry/Widgets/TextWidget/index.jsx
+++ b/packages/blueberry/Widgets/TextWidget/index.jsx
@@ -23,7 +23,6 @@ const TextWidget = ({
 }) => {
   return (
     <InputField
-      autoComplete="none"
       tooltipConfig={getTooltipConfig(meta)}
       required={isRequired}
       optional={isOptional}


### PR DESCRIPTION
* remove the `none` from autoComplete prop of the InputField component to use the Blueberry default that is already `off`
* `none` wasn't being considered by chrome as `off` for example and `on` autocomplete caused form issues like:
    - valid fully filled form with submit button disabled