### PR TITLE
fix: :bug: currency widget autofill bug fixed

### DIFF
--- a/packages/blueberry/Widgets/CurrencyWidget/index.jsx
+++ b/packages/blueberry/Widgets/CurrencyWidget/index.jsx
@@ -3,7 +3,8 @@ import useCurrencyWidget from "../../hooks/useCurrencyWidget"
 import TextWidget from "../TextWidget"
 
 const CurrencyWidget = (props) => {
-  const { moneyMask, fieldValue } = useCurrencyWidget()
+  const { value } = props
+  const { moneyMask, fieldValue } = useCurrencyWidget({value})
 
   return <TextWidget {...props} onChange={moneyMask} value={fieldValue} />
 }

--- a/packages/blueberry/hooks/useCurrencyWidget.js
+++ b/packages/blueberry/hooks/useCurrencyWidget.js
@@ -1,7 +1,11 @@
-import { useState } from "react"
+import { useState, useEffect } from "react"
 
-export default function useCurrencyWidget() {
+export default function useCurrencyWidget({value}) {
   const [fieldValue, setFieldValue] = useState("")
+
+  useEffect(() => {
+    moneyMask(value)
+  }, [value])
 
   const moneyMask = (rawValue) => {
     if (rawValue === null) rawValue = ""


### PR DESCRIPTION
Currency widget autofill bug fixed.

---

#### Description

The autofill on the Currency Widget wasn't working correctly. 
When there was a value on the autofill, the currency field wasn't showing the initial autofilled value.

This was fixed by forcing an update on the internal fieldValue on the hook with the new value whenever the value is updated.