### PR TITLE
fix: add sublabel as select label

### DIFF
--- a/packages/atlas-theme/Widgets/SelectWidget/index.jsx
+++ b/packages/atlas-theme/Widgets/SelectWidget/index.jsx
@@ -15,7 +15,7 @@ const SelectWidget = ({
   options = [],
   label,
   placeholder,
-
+  sublabel,
   hasError,
   errorMessage,
   fieldId,
@@ -116,7 +116,7 @@ const SelectWidget = ({
         </div>
 
         <label htmlFor={slug}>
-          {placeholder}
+          {sublabel}
         </label>
 
         {hasError && errorMessage ? <span


### PR DESCRIPTION
On Atlas theme, the select widget wasn't setting the sublabel as label as it was happening on other widgets