### PR TITLE
fix: select widget on safari (ios)

### DIFF
--- a/packages/atlas-theme/Widgets/SelectWidget/index.jsx
+++ b/packages/atlas-theme/Widgets/SelectWidget/index.jsx
@@ -55,14 +55,7 @@ const SelectWidget = ({
     setSelectedLabel((prevState) => labelSelected ?? prevState)
     onChange(valueSelected)
 
-    const pointerType = e.nativeEvent.pointerType
-    const codeType = e.nativeEvent.code
-    if (
-      ["mouse", "touch"].includes(pointerType) ||
-      ["Enter", "Space"].includes(codeType)
-    ) {
-      selectRef.current?.click()
-    }
+    selectRef.current.dispatchEvent(new MouseEvent('click', { bubbles: true }));
   }
 
   function removeAccents(value) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

#### Description
This PR fixes a bug on selectwidget component (atlas theme) witch appears only in safari (ios).


---