### PR TITLE
[ATLAS-THEME] Fix type comparison 

### DIFF
--- a/packages/atlas-theme/Widgets/SelectSearchWidget/index.jsx
+++ b/packages/atlas-theme/Widgets/SelectSearchWidget/index.jsx
@@ -66,7 +66,9 @@ const SelectSearchWidget = ({
 
   useEffect(() => {
     if (value) {
-      const optionSelected = options.find((option) => option.value === value)
+      const optionSelected = options.find(
+        (option) => option.value.toString() === value
+      )
       setSelectedOption(optionSelected)
     }
   }, [])
@@ -159,11 +161,11 @@ const SelectSearchWidget = ({
                   data-label={option.label}
                   onClick={onClickOption}
                   onKeyDown={onClickOption}
-                  defaultChecked={selectedOption.value === option.value}
+                  defaultChecked={selectedOption?.value === option.value}
                 />
 
                 <span className="ac-select__option-label">{option.label}</span>
-                {selectedOption.value === option.value ? (
+                {selectedOption?.value === option.value ? (
                   <img src={IconCheck} />
                 ) : null}
               </div>

--- a/packages/atlas-theme/Widgets/SelectWidget/index.jsx
+++ b/packages/atlas-theme/Widgets/SelectWidget/index.jsx
@@ -73,10 +73,12 @@ const SelectWidget = ({
 
   useEffect(() => {
     if (value) {
-      const optionSelected = options.find((option) => option.value === value)
+      const optionSelected = options.find(
+        (option) => option.value.toString() === value
+      )
       setSelectedOption(optionSelected)
     }
-  }, [])
+  }, [value])
 
   function onClickOption(e) {
     if (disabled) return
@@ -166,11 +168,11 @@ const SelectWidget = ({
                   data-label={option.label}
                   onClick={onClickOption}
                   onKeyDown={onClickOption}
-                  defaultChecked={selectedOption.value === option.value}
+                  defaultChecked={selectedOption?.value === option.value}
                 />
 
                 <span className="ac-select__option-label">{option.label}</span>
-                {selectedOption.value === option.value ? (
+                {selectedOption?.value === option?.value ? (
                   <img src={IconCheck} />
                 ) : null}
               </div>


### PR DESCRIPTION
Fix comparison types.

The select value type always is a string. When firebolt option list comes with a different type we never find a match to fill select value.