### PR TITLE
feat: add required asterisk to form labels (atlas)

### DIFF
--- a/packages/atlas-theme/Widgets/SelectSearchWidget/index.jsx
+++ b/packages/atlas-theme/Widgets/SelectSearchWidget/index.jsx
@@ -15,6 +15,7 @@ const SelectSearchWidget = ({
   label,
   sublabel,
   placeholder,
+  isRequired,
 
   hasError,
   errorMessage,
@@ -146,7 +147,7 @@ const SelectSearchWidget = ({
             </div>
           </div>
 
-          <label htmlFor={slug}>{sublabel}</label>
+          <label htmlFor={slug} className={classNames({ required: isRequired })}>{sublabel}</label>
 
           {hasError && errorMessage ? (
             <span className="input-error-message">{errorMessage}</span>

--- a/packages/atlas-theme/Widgets/SelectWidget/index.jsx
+++ b/packages/atlas-theme/Widgets/SelectWidget/index.jsx
@@ -20,9 +20,9 @@ const SelectWidget = ({
   errorMessage,
   fieldId,
   disabled = false,
-
   onChange,
   value,
+  isRequired
 }) => {
   const selectRef = useRef(null)
   const [isOpenSelect, setIsOpenSelect] = useState(false)
@@ -152,8 +152,7 @@ const SelectWidget = ({
               )}
             </div>
           </div>
-
-          <label htmlFor={slug}>{sublabel}</label>
+          <label htmlFor={slug} className={classNames({ required: isRequired })}>{sublabel}</label>
 
           {hasError && errorMessage ? (
             <span className="input-error-message">{errorMessage}</span>

--- a/packages/atlas-theme/Widgets/SelectWidget/styles.scss
+++ b/packages/atlas-theme/Widgets/SelectWidget/styles.scss
@@ -71,6 +71,11 @@
     transition: all 0.3s ease-out;
     transform: translate(0px, -90px);
     display: block;
+    &.required::after {
+      content: " *";
+      color: #E52222; 
+      font-weight: bold;
+    }
   }
 
   &__button {

--- a/packages/atlas-theme/Widgets/TextWidget/index.jsx
+++ b/packages/atlas-theme/Widgets/TextWidget/index.jsx
@@ -1,5 +1,6 @@
 import React from "react"
 import FieldHolder from "../../FieldHolder"
+import classNames from "classnames";
 
 const TextWidget = ({
   // html attributtes
@@ -48,7 +49,7 @@ const TextWidget = ({
           max={max}
         />
 
-        <label htmlFor={slug}>
+        <label htmlFor={slug} className={classNames({ required: isRequired })}>
           {sublabel}
         </label>
 

--- a/packages/atlas-theme/styles.scss
+++ b/packages/atlas-theme/styles.scss
@@ -45,6 +45,11 @@
     transition: all .3s ease-out;
     transform: translate(0px, -90px);
     display: block;
+    &.required::after {
+      content: " *";
+      color: #E52222; 
+      font-weight: bold;
+    }
   }
 
   input {


### PR DESCRIPTION
- adds an asterisk for required fields (`textWidget` and `selectWidget`) via CSS.