### PR TITLE
Fix:CurrencyWidget onChange

### DIFF
--- a/packages/blueberry/Widgets/CurrencyWidget/index.jsx
+++ b/packages/blueberry/Widgets/CurrencyWidget/index.jsx
@@ -3,8 +3,8 @@ import useCurrencyWidget from "../../hooks/useCurrencyWidget"
 import TextWidget from "../TextWidget"
 
 const CurrencyWidget = (props) => {
-  const { value } = props
-  const { moneyMask, fieldValue } = useCurrencyWidget({value})
+  const { value, onChange } = props
+  const { moneyMask, fieldValue } = useCurrencyWidget({ value, onChange })
 
   return <TextWidget {...props} onChange={moneyMask} value={fieldValue} />
 }


### PR DESCRIPTION
This pull request includes a change to the `CurrencyWidget` component in the `packages/blueberry/Widgets/CurrencyWidget/index.jsx` file. The change improves the functionality of the widget by adding an `onChange` prop to the `useCurrencyWidget` hook and updating the component to use this new prop.

Changes to `CurrencyWidget` component:

* [`packages/blueberry/Widgets/CurrencyWidget/index.jsx`](diffhunk://#diff-d72898b1add20044ff88cb60bcd81932646b6f1263c5a1f4e777d22620c4727fL6-R7): Added `onChange` prop to `useCurrencyWidget` hook and updated the `CurrencyWidget` component to pass the `onChange` prop and use it within the hook.