### PR TITLE
fix: add set time out in select widget to onBlur function

### DIFF
--- a/packages/aurora-theme/Widgets/SelectWidget/index.jsx
+++ b/packages/aurora-theme/Widgets/SelectWidget/index.jsx
@@ -31,7 +31,7 @@ const SelectWidget = ({
         errorMessage={errorMessage}
         disabled={disabled}
         onChange={onChange}
-        onBlur={onBlur}
+        onBlur={() => setTimeout(() => onBlur(), 100)}
       />
     </FieldHolder>
   )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

#### Description

<!--- Describe your changes in detail -->

---

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Essa alteração foi precisa para não "piscar" o erro no componente. Como o select é um componente customizado, ao clicar em alguma opção do box, a função de onBlur já é acionada antes de coletarmos o value.

---

#### Screenshots and links

---