### PR TITLE
FIX: Returning user

### DIFF
--- a/packages/client-core/lib/FireboltFormEngine.ts
+++ b/packages/client-core/lib/FireboltFormEngine.ts
@@ -90,6 +90,15 @@ class FireboltFormEngine {
     })
 
     createFormSession(this.formName, formattedData?.auth)
+    if (fireboltId) {
+      const urlParams = new URLSearchParams(window.location.search)
+      urlParams.delete("firebolt_id")
+      window.history.replaceState(
+        {},
+        document.title,
+        `${window.location.pathname}?${urlParams.toString()}`
+      )
+    }
     return formattedData
   }
 


### PR DESCRIPTION
Remove firebolt_id from url after use.

This avoid duplicate the firebolt between forms.

If user leaves Caixa form and enter on BB with this param on url, the backend create a new form with the same firebolt_id