### PR TITLE
feat: add grow prop to half style input

### DIFF
--- a/packages/client-core/lib/types.ts
+++ b/packages/client-core/lib/types.ts
@@ -125,6 +125,8 @@ export interface IStepConfigField {
   }[]
   "ui:styles"?: {
     size: "full" | "half"
+    grow?: "1" | "2" | "3"
+
   }
   meta: Object
   component: string

--- a/packages/client/src/components/FireboltForm/InputHolder/hook/index.ts
+++ b/packages/client/src/components/FireboltForm/InputHolder/hook/index.ts
@@ -84,6 +84,8 @@ export default function useInputHolder({
 
   const computedClasses = classNames(classes["firebolt-input"], {
     [classes["firebolt-input--half"]]: propsStyles?.size === "half",
+    [classes["firebolt-input--half-2"]]: propsStyles?.size === "half" && propsStyles?.grow === '2',
+    [classes["firebolt-input--half-3"]]: propsStyles?.size === "half" && propsStyles?.grow === '3',
   })
 
   // props from 'ui:props-conditional json key

--- a/packages/client/src/components/FireboltForm/style.module.css
+++ b/packages/client/src/components/FireboltForm/style.module.css
@@ -18,8 +18,16 @@
   gap: 24px;
 }
 
-@media (min-width: 720px) {
+@media (min-width: 320px) {
   .firebolt-input.firebolt-input--half {
-    width: 48%;
+    flex: 1;
+  }
+
+  .firebolt-input.firebolt-input--half-2 {
+    flex: 2;
+  }
+
+  .firebolt-input.firebolt-input--half-3 {
+    flex: 3;
   }
 }

--- a/packages/json-schema/form-schema.json
+++ b/packages/json-schema/form-schema.json
@@ -454,6 +454,13 @@
                                   "title": "field size",
                                   "enum": ["half", "full"],
                                   "type": "string"
+                                },
+                                "grow": {
+                                  "$id": "#/properties/steps/items/anyOf/0/properties/step/properties/fields/items/anyOf/0/properties/ui%3Astyles/grow",
+                                  "description": "Set size half field",
+                                  "title": "field size when its half",
+                                  "enum": ["1", "2", "3"],
+                                  "type": "number"
                                 }
                               }
                             },


### PR DESCRIPTION
Este PR adiciona a possibilidade de half (dois inputs/selects na mesma coluna) e definição do valor do flex-grow desejado para cada elemento. Para utilizar essa opção, adicione em sua config:

```
"ui:styles": {
          "size": "half",
          "grow": "2"
        },
```


 exemplos de aplicação:

valor default: grow 1 / grow 1
![image](https://github.com/user-attachments/assets/20ddb3b2-ab2b-4fe6-a10d-ba79f0c6d0cc)

grow 3 / grow 2
![image](https://github.com/user-attachments/assets/a59a2f99-e226-4e82-8038-05a02e32862a)]

grow 2 / grow 1 (ou não informa)
![image](https://github.com/user-attachments/assets/08e95ef7-d117-4ca6-9771-acb826e06a95)

grow 3  / grow 1 (ou não informa)
![image](https://github.com/user-attachments/assets/3a051f08-066b-40c4-a074-d0eb159986fc)

grow 1 (ou não informa) / grow 2
![image](https://github.com/user-attachments/assets/6353a592-b248-4bc7-929e-41c6d5ad3dd4)

